### PR TITLE
Integrate DonationAlerts polling

### DIFF
--- a/Source/RimConnection/API/DonationAlertsAPI.cs
+++ b/Source/RimConnection/API/DonationAlertsAPI.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using RestSharp;
+using Verse;
+
+namespace RimConnection
+{
+    public class DonationAlertsAPI
+    {
+        private static readonly RestClient client = new RestClient("https://www.donationalerts.com/api/v1/");
+        private static int lastId = 0;
+
+        public class Donation
+        {
+            public int id { get; set; }
+            public string name { get; set; }
+            public string username { get; set; }
+            public string message { get; set; }
+            public float amount { get; set; }
+            public string currency { get; set; }
+            public int is_shown { get; set; }
+            public string created_at { get; set; }
+            public string shown_at { get; set; }
+        }
+
+        public class DonationResponse
+        {
+            public List<Donation> data { get; set; }
+        }
+
+        public static List<Donation> GetNewDonations()
+        {
+            if (string.IsNullOrEmpty(RimConnectSettings.donationAlertsToken))
+            {
+                return new List<Donation>();
+            }
+
+            var request = new RestRequest("alerts/donations", Method.GET);
+            request.AddHeader("Authorization", $"Bearer {RimConnectSettings.donationAlertsToken}");
+
+            var response = client.Execute<DonationResponse>(request);
+            if (response.StatusCode != System.Net.HttpStatusCode.OK)
+            {
+                Log.Error($"DonationAlerts API error: {response.StatusCode}");
+                return new List<Donation>();
+            }
+
+            var donations = response.Data?.data ?? new List<Donation>();
+            var newDonations = donations.Where(d => d.id > lastId).OrderBy(d => d.id).ToList();
+            if (newDonations.Count > 0)
+            {
+                lastId = newDonations.Last().id;
+            }
+            return newDonations;
+        }
+    }
+}

--- a/Source/RimConnection/DonationAlertsPoller.cs
+++ b/Source/RimConnection/DonationAlertsPoller.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading.Tasks;
 using Verse;
+using RimConnection.Settings;
 
 namespace RimConnection
 {

--- a/Source/RimConnection/DonationAlertsPoller.cs
+++ b/Source/RimConnection/DonationAlertsPoller.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
+using Verse;
+
+namespace RimConnection
+{
+    class DonationAlertsPoller : GameComponent
+    {
+        static DateTime lastCheck = DateTime.UtcNow;
+        static readonly TimeSpan interval = TimeSpan.FromSeconds(30d);
+        static ConcurrentQueue<Command> queue = new ConcurrentQueue<Command>();
+
+        public DonationAlertsPoller(Game game)
+        {
+        }
+
+        public override void GameComponentTick()
+        {
+            if (DateTime.UtcNow - lastCheck > interval)
+            {
+                lastCheck = DateTime.UtcNow;
+                CheckDonations();
+            }
+
+            if (queue.TryDequeue(out Command command))
+            {
+                IAction action = ActionList.actionLookup[command.actionHash];
+                action.Execute(command.amount, command.boughtBy);
+                Find.TickManager.slower.SignalForceNormalSpeedShort();
+            }
+        }
+
+        public static async void CheckDonations()
+        {
+            await Task.Run(() =>
+            {
+                var donations = DonationAlertsAPI.GetNewDonations();
+                foreach (var donation in donations)
+                {
+                    var cmd = DonationToCommand(donation.amount);
+                    if (cmd != null)
+                    {
+                        queue.Enqueue(cmd);
+                    }
+                }
+            });
+        }
+
+        private static Command DonationToCommand(float amount)
+        {
+            int val = (int)Math.Round(amount);
+            var option = CommandOptionListController.commandOptionList?.commandOptions
+                .FirstOrDefault(co => co.costSilverStore == val);
+            if (option == null) return null;
+            return new Command
+            {
+                actionHash = option.actionHash,
+                amount = val,
+                boughtBy = "DonationAlerts"
+            };
+        }
+    }
+}

--- a/Source/RimConnection/RimConnection.csproj
+++ b/Source/RimConnection/RimConnection.csproj
@@ -118,9 +118,11 @@
     <Compile Include="Managers\PawnCreationManager.cs" />
     <Compile Include="RimConnection.cs" />
     <Compile Include="API\RimConnectAPI.cs" />
+    <Compile Include="API\DonationAlertsAPI.cs" />
     <Compile Include="Managers\DropPodManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ServerInitialise.cs" />
+    <Compile Include="DonationAlertsPoller.cs" />
     <Compile Include="Actions\Action.cs" />
     <Compile Include="Settings\Settings.cs" />
     <Compile Include="API\CommandList.cs" />

--- a/Source/RimConnection/Settings/Settings.cs
+++ b/Source/RimConnection/Settings/Settings.cs
@@ -19,9 +19,11 @@ namespace RimConnection
 
         public static string secret = "";
         public static string token = "";
+        public static string donationAlertsToken = "";
         public static bool initialiseSuccessful = false;
 
         bool showSecret = false;
+        bool showDonationToken = false;
 
         public static int silverAwardPoints = -1;
 
@@ -33,6 +35,7 @@ namespace RimConnection
 
             Scribe_Values.Look<string>(ref secret, "secret", "", true);
             Scribe_Values.Look(ref silverAwardPoints, "silverAwardPoints");
+            Scribe_Values.Look(ref donationAlertsToken, "donationAlertsToken", "");
 
         }
 
@@ -109,7 +112,38 @@ namespace RimConnection
 
             GUI.EndGroup();
 
-            Rect loyaltyStoreHeader = new Rect(0, secretGroup.y + secretGroup.height + 10f, rect.width, 64f);
+            Rect daGroup = new Rect(0, secretGroup.y + secretGroup.height + 10f, rect.width, 72f);
+            GUI.BeginGroup(daGroup);
+
+            Rect daLabel = new Rect(0, 0, defaultWidth, 24f);
+            Rect daWarning = new Rect(0, 48, 400f, 24f);
+            Widgets.Label(daLabel, "DA Token:");
+            daLabel.x = daLabel.width + WidgetRow.LabelGap;
+
+            if (showDonationToken)
+            {
+                donationAlertsToken = Widgets.TextField(daLabel, donationAlertsToken);
+            }
+            else
+            {
+                Widgets.Label(daLabel, new string('*', donationAlertsToken.Length));
+            }
+
+            daLabel.x += daLabel.width + WidgetRow.LabelGap;
+            if (!showDonationToken && Widgets.ButtonText(daLabel, "Show"))
+            {
+                showDonationToken = true;
+            }
+            else if (Widgets.ButtonText(daLabel, "Hide"))
+            {
+                showDonationToken = false;
+            }
+
+            Widgets.Label(daWarning, "<color=red>Keep this token private!</color>");
+
+            GUI.EndGroup();
+
+            Rect loyaltyStoreHeader = new Rect(0, daGroup.y + daGroup.height + 10f, rect.width, 64f);
             Widgets.Label(loyaltyStoreHeader, "<size=32>Loyalty Settings</size>");
 
             Rect itemStoreGroup = new Rect(0, loyaltyStoreHeader.y + loyaltyStoreHeader.height + 10f, rect.width, 24f);


### PR DESCRIPTION
## Summary
- add simple DonationAlerts API client and poller component
- store DonationAlerts token in mod settings with UI field
- include new classes in project build

## Testing
- `curl -I https://www.donationalerts.com/api/v1/alerts/donations` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6862081900b8832a93b37704a3e6400b