### PR TITLE
Integrate DonationAlerts

### DIFF
--- a/Source/RimConnection/API/DonationAlerts.cs
+++ b/Source/RimConnection/API/DonationAlerts.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+
+namespace RimConnection
+{
+    public class DonationAlertsResponse
+    {
+        public List<DonationAlert> data { get; set; }
+    }
+
+    public class DonationAlert
+    {
+        public int id { get; set; }
+        public string username { get; set; }
+        public string message { get; set; }
+        public double amount { get; set; }
+        public string currency { get; set; }
+    }
+}

--- a/Source/RimConnection/DonationInitialise.cs
+++ b/Source/RimConnection/DonationInitialise.cs
@@ -16,6 +16,9 @@ namespace RimConnection
 
         public static void Init()
         {
+            // Ensure HTTPS requests use TLS 1.2 which DonationAlerts requires.
+            System.Net.ServicePointManager.SecurityProtocol |= System.Net.SecurityProtocolType.Tls12;
+
             // Build the lookup of all actions and generate a default command option list.
             ActionList.GenerateActionLookup();
             var validCommands = ActionList.ActionListToApi().validCommands;

--- a/Source/RimConnection/DonationInitialise.cs
+++ b/Source/RimConnection/DonationInitialise.cs
@@ -1,0 +1,30 @@
+using Verse;
+
+namespace RimConnection
+{
+    /// <summary>
+    /// Initializes the command option list after game defs are loaded.
+    /// This replaces the old server-based initialization logic.
+    /// </summary>
+    [StaticConstructorOnStartup]
+    public static class DonationInitialise
+    {
+        static DonationInitialise()
+        {
+            Init();
+        }
+
+        public static void Init()
+        {
+            // Build the lookup of all actions and generate a default command option list.
+            ActionList.GenerateActionLookup();
+            var validCommands = ActionList.ActionListToApi().validCommands;
+            Settings.CommandOptionListController.commandOptionList = new CommandOptionList
+            {
+                commandOptions = validCommands.ConvertAll(vc => vc.toCommandOption())
+            };
+            Log.Message($"[RimConnect] Initialized {Settings.CommandOptionListController.commandOptionList.commandOptions.Count} events locally.");
+        }
+    }
+}
+

--- a/Source/RimConnection/DonationPoller.cs
+++ b/Source/RimConnection/DonationPoller.cs
@@ -45,8 +45,8 @@ namespace RimConnection
             {
                 try
                 {
-                    // Force TLS 1.2 for HTTPS requests
-                    System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
+                    // Ensure TLS 1.2 is enabled for HTTPS requests
+                    System.Net.ServicePointManager.SecurityProtocol |= System.Net.SecurityProtocolType.Tls12;
                     var client = new RestClient("https://www.donationalerts.com/api/v1/");
                     var request = new RestRequest("alerts/donations", Method.GET);
                     request.AddHeader("Authorization", $"Bearer {RimConnectSettings.donationToken}");

--- a/Source/RimConnection/DonationPoller.cs
+++ b/Source/RimConnection/DonationPoller.cs
@@ -45,6 +45,8 @@ namespace RimConnection
             {
                 try
                 {
+                    // Force TLS 1.2 for HTTPS requests
+                    System.Net.ServicePointManager.SecurityProtocol |= System.Net.SecurityProtocolType.Tls12;
                     var client = new RestClient("https://www.donationalerts.com/api/v1/");
                     var request = new RestRequest("alerts/donations", Method.GET);
                     request.AddHeader("Authorization", $"Bearer {RimConnectSettings.donationToken}");

--- a/Source/RimConnection/DonationPoller.cs
+++ b/Source/RimConnection/DonationPoller.cs
@@ -46,7 +46,7 @@ namespace RimConnection
                 try
                 {
                     // Force TLS 1.2 for HTTPS requests
-                    System.Net.ServicePointManager.SecurityProtocol |= System.Net.SecurityProtocolType.Tls12;
+                    System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
                     var client = new RestClient("https://www.donationalerts.com/api/v1/");
                     var request = new RestRequest("alerts/donations", Method.GET);
                     request.AddHeader("Authorization", $"Bearer {RimConnectSettings.donationToken}");

--- a/Source/RimConnection/DonationPoller.cs
+++ b/Source/RimConnection/DonationPoller.cs
@@ -14,7 +14,9 @@ namespace RimConnection
         private static DateTime lastCheckTime = DateTime.UtcNow;
         private static ConcurrentQueue<Command> commandQueue = new ConcurrentQueue<Command>();
 
-        public DonationPoller(Game game) : base(game) { }
+        public DonationPoller(Game game)
+        {
+        }
 
         public override void GameComponentTick()
         {

--- a/Source/RimConnection/DonationPoller.cs
+++ b/Source/RimConnection/DonationPoller.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using RestSharp;
+using Verse;
+
+namespace RimConnection
+{
+    public class DonationPoller : GameComponent
+    {
+        public static int lastDonationId = 0;
+        private static readonly TimeSpan checkInterval = TimeSpan.FromSeconds(10);
+        private static DateTime lastCheckTime = DateTime.UtcNow;
+        private static ConcurrentQueue<Command> commandQueue = new ConcurrentQueue<Command>();
+
+        public DonationPoller(Game game) : base(game) { }
+
+        public override void GameComponentTick()
+        {
+            if (RimConnectSettings.initialiseSuccessful)
+            {
+                if (DateTime.UtcNow - lastCheckTime > checkInterval)
+                {
+                    lastCheckTime = DateTime.UtcNow;
+                    CheckForDonations();
+                }
+            }
+
+            if (commandQueue.TryDequeue(out Command cmd))
+            {
+                if (ActionList.actionLookup != null && ActionList.actionLookup.TryGetValue(cmd.actionHash, out IAction action))
+                {
+                    action.Execute(cmd.amount, cmd.boughtBy);
+                    Find.TickManager.slower.SignalForceNormalSpeedShort();
+                }
+            }
+        }
+
+        public static async void CheckForDonations()
+        {
+            await Task.Run(() =>
+            {
+                try
+                {
+                    var client = new RestClient("https://www.donationalerts.com/api/v1/");
+                    var request = new RestRequest("alerts/donations", Method.GET);
+                    request.AddHeader("Authorization", $"Bearer {RimConnectSettings.donationToken}");
+                    var response = client.Execute<DonationAlertsResponse>(request);
+                    if (response.StatusCode == System.Net.HttpStatusCode.OK && response.Data != null)
+                    {
+                        var donations = response.Data.data;
+                        if (donations != null)
+                        {
+                            List<DonationAlert> newDonations = new List<DonationAlert>();
+                            foreach (var donation in donations)
+                            {
+                                if (donation.id > lastDonationId)
+                                    newDonations.Add(donation);
+                            }
+
+                            if (newDonations.Count > 0)
+                            {
+                                newDonations.Sort((a, b) => a.id.CompareTo(b.id));
+                                foreach (var donation in newDonations)
+                                {
+                                    int amountInt = (int)Math.Floor(donation.amount);
+                                    var optionList = Settings.CommandOptionListController.commandOptionList;
+                                    if (optionList != null)
+                                    {
+                                        var match = optionList.commandOptions.Find(opt => opt.costSilverStore == amountInt);
+                                        if (match != null)
+                                        {
+                                            Command newCommand = new Command
+                                            {
+                                                actionHash = match.actionHash,
+                                                amount = 1,
+                                                boughtBy = donation.username
+                                            };
+                                            commandQueue.Enqueue(newCommand);
+                                            Log.Message($"[RimConnect] Queued event for donation {donation.amount} {donation.currency} from {donation.username}");
+                                        }
+                                        else
+                                        {
+                                            Log.Message($"[RimConnect] Donation of {donation.amount}{donation.currency} from {donation.username} does not match any configured event.");
+                                        }
+                                    }
+                                    if (donation.id > lastDonationId)
+                                        lastDonationId = donation.id;
+                                }
+                            }
+                        }
+                    }
+                    else if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                    {
+                        Log.Error("[RimConnect] DonationAlerts token unauthorized or expired. Stopping connection.");
+                        RimConnectSettings.initialiseSuccessful = false;
+                    }
+                    else
+                    {
+                        Log.Error($"[RimConnect] Failed to fetch donations. HTTP {response.StatusCode}: {response.ErrorMessage}");
+                    }
+                }
+                catch (Exception e)
+                {
+                    Log.Error("[RimConnect] Error in donation check: " + e.Message);
+                }
+            });
+        }
+    }
+}

--- a/Source/RimConnection/RimConnection.cs
+++ b/Source/RimConnection/RimConnection.cs
@@ -10,7 +10,6 @@ namespace RimConnection
         public RimConnection(ModContentPack content) : base(content)
         {
             settings = GetSettings<RimConnectSettings>();
-            InitializeEventList();
         }
 
         public override void DoSettingsWindowContents(Rect inRect)
@@ -23,15 +22,7 @@ namespace RimConnection
             return "RimConnect";
         }
 
-        private void InitializeEventList()
-        {
-            ActionList.GenerateActionLookup();
-            var validCommands = ActionList.ActionListToApi().validCommands;
-            Settings.CommandOptionListController.commandOptionList = new CommandOptionList()
-            {
-                commandOptions = validCommands.ConvertAll(vc => vc.toCommandOption())
-            };
-            Log.Message($"[RimConnect] Initialized {Settings.CommandOptionListController.commandOptionList.commandOptions.Count} events locally.");
-        }
+        // Event list generation now occurs after game defs are loaded via
+        // DonationInitialise to ensure DefOfs are available.
     }
 }

--- a/Source/RimConnection/RimConnection.cs
+++ b/Source/RimConnection/RimConnection.cs
@@ -1,26 +1,37 @@
-﻿using UnityEngine;
+using UnityEngine;
 using Verse;
 
 namespace RimConnection
 {
-    public class RimConnection: Mod
+    public class RimConnection : Mod
     {
         RimConnectSettings settings;
 
-
         public RimConnection(ModContentPack content) : base(content)
         {
-            this.settings = GetSettings<RimConnectSettings>();
+            settings = GetSettings<RimConnectSettings>();
+            InitializeEventList();
         }
 
         public override void DoSettingsWindowContents(Rect inRect)
         {
-            this.settings.DoWindowContents(inRect);
+            settings.DoWindowContents(inRect);
         }
 
         public override string SettingsCategory()
         {
             return "RimConnect";
+        }
+
+        private void InitializeEventList()
+        {
+            ActionList.GenerateActionLookup();
+            var validCommands = ActionList.ActionListToApi().validCommands;
+            Settings.CommandOptionListController.commandOptionList = new CommandOptionList()
+            {
+                commandOptions = validCommands.ConvertAll(vc => vc.toCommandOption())
+            };
+            Log.Message($"[RimConnect] Initialized {Settings.CommandOptionListController.commandOptionList.commandOptions.Count} events locally.");
         }
     }
 }

--- a/Source/RimConnection/RimConnection.csproj
+++ b/Source/RimConnection/RimConnection.csproj
@@ -113,6 +113,8 @@
     <Compile Include="Settings\CommandOptionSettings.cs" />
     <Compile Include="Managers\AlertManager.cs" />
     <Compile Include="DonationPoller.cs" />
+    <Compile Include="ServerPoller.cs" />
+    <Compile Include="SetWorldName.cs" />
     <Compile Include="API/DonationAlerts.cs" />
     <Compile Include="Managers\PawnCreationManager.cs" />
     <Compile Include="RimConnection.cs" />

--- a/Source/RimConnection/RimConnection.csproj
+++ b/Source/RimConnection/RimConnection.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Managers\AlertManager.cs" />
     <Compile Include="DonationPoller.cs" />
     <Compile Include="ServerPoller.cs" />
+    <Compile Include="DonationInitialise.cs" />
     <Compile Include="SetWorldName.cs" />
     <Compile Include="API/DonationAlerts.cs" />
     <Compile Include="Managers\PawnCreationManager.cs" />

--- a/Source/RimConnection/RimConnection.csproj
+++ b/Source/RimConnection/RimConnection.csproj
@@ -102,10 +102,8 @@
     <Compile Include="Actions\Orbital\OrbitalBombardmentAction.cs" />
     <Compile Include="Actions\Orbital\TornadoAction.cs" />
     <Compile Include="Actions\Weather\WeatherAction.cs" />
-    <Compile Include="API\AuthMod.cs" />
     <Compile Include="API\CommandOption.cs" />
     <Compile Include="API\Config.cs" />
-    <Compile Include="API\PostWorld.cs" />
     <Compile Include="API\ValidCommand.cs" />
     <Compile Include="IncidentWorkers\IncidentWorker_AlphaBeavers.cs" />
     <Compile Include="Patches\MPCompat.cs" />
@@ -114,17 +112,15 @@
     <Compile Include="Settings\ResetCommandOptionsModal.cs" />
     <Compile Include="Settings\CommandOptionSettings.cs" />
     <Compile Include="Managers\AlertManager.cs" />
-    <Compile Include="ServerPoller.cs" />
+    <Compile Include="DonationPoller.cs" />
+    <Compile Include="API/DonationAlerts.cs" />
     <Compile Include="Managers\PawnCreationManager.cs" />
     <Compile Include="RimConnection.cs" />
-    <Compile Include="API\RimConnectAPI.cs" />
     <Compile Include="Managers\DropPodManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ServerInitialise.cs" />
     <Compile Include="Actions\Action.cs" />
     <Compile Include="Settings\Settings.cs" />
     <Compile Include="API\CommandList.cs" />
-    <Compile Include="SetWorldName.cs" />
     <Compile Include="Windows\TextInputWindow.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/RimConnection/ServerPoller.cs
+++ b/Source/RimConnection/ServerPoller.cs
@@ -6,11 +6,13 @@ namespace RimConnection
     // It now simply uses the DonationPoller logic.
     class ServerPoller : DonationPoller
     {
-        public ServerPoller(Game game) : base(game)
+        public ServerPoller(Game game)
+            : base(game)
         {
         }
 
-        public ServerPoller() : base(null)
+        public ServerPoller()
+            : base(null)
         {
         }
     }

--- a/Source/RimConnection/ServerPoller.cs
+++ b/Source/RimConnection/ServerPoller.cs
@@ -1,70 +1,17 @@
-﻿using Multiplayer.API;
-using System;
-using System.Collections;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Verse;
 
 namespace RimConnection
 {
-    class ServerPoller : GameComponent
+    // Legacy class retained for backward compatibility with older save games.
+    // It now simply uses the DonationPoller logic.
+    class ServerPoller : DonationPoller
     {
-        static DateTime lastGETRequest = DateTime.UtcNow;
-        static readonly TimeSpan timeBetweenRequests = TimeSpan.FromSeconds(30d);
-        static ConcurrentQueue<Command> commandQueue = new ConcurrentQueue<Command>();
-
-        private DateTime previousDateTime;
-
-        public ServerPoller(Game game)
+        public ServerPoller(Game game) : base(game)
         {
         }
 
-        public override void FinalizeInit()
+        public ServerPoller() : base(null)
         {
-            previousDateTime = DateTime.Now;
-        }
-
-        public override void GameComponentTick()
-        {
-            // Only do this stuff if the mod successfully connected to the server
-            if (RimConnectSettings.initialiseSuccessful)
-            {
-                if (DateTime.UtcNow - lastGETRequest > timeBetweenRequests)
-                {
-                    lastGETRequest = DateTime.UtcNow;
-                    ServerChecker();
-                }
-            }
-
-            if (commandQueue.TryDequeue(out Command command))
-            {
-                IAction action = ActionList.actionLookup[command.actionHash];
-                action.Execute(command.amount, command.boughtBy);
-                Find.TickManager.slower.SignalForceNormalSpeedShort();
-            }
-        }
-
-        public static async void ServerChecker()
-        {
-            await Task.Run(() =>
-                {
-                    List<Command> commands = RimConnectAPI.GetCommands();
-
-                    foreach (Command command in commands)
-                    {
-                        addCommandToQueue(command);
-                    }
-                });
-
-            return;
-        }
-
-        [SyncMethod]
-        public static void addCommandToQueue(Command command)
-        {
-            commandQueue.Enqueue(command);
         }
     }
 }

--- a/Source/RimConnection/SetWorldName.cs
+++ b/Source/RimConnection/SetWorldName.cs
@@ -1,15 +1,15 @@
-﻿using System;
 using Verse;
 
 namespace RimConnection
 {
+    // Legacy component kept for compatibility with older save games.
     class SetWorldName : GameComponent
     {
-        public SetWorldName(Game game)
+        public SetWorldName(Game game) : base(game)
         {
         }
 
-        public SetWorldName()
+        public SetWorldName() : base(null)
         {
         }
 
@@ -18,7 +18,7 @@ namespace RimConnection
             base.FinalizeInit();
             string worldName = Find.World.info.name;
             Log.Message($"World name is {worldName}");
-            RimConnectAPI.UpdateWorld(worldName);
+            // Previously this sent the world name to a server. No longer needed.
         }
     }
 }

--- a/Source/RimConnection/SetWorldName.cs
+++ b/Source/RimConnection/SetWorldName.cs
@@ -5,11 +5,11 @@ namespace RimConnection
     // Legacy component kept for compatibility with older save games.
     class SetWorldName : GameComponent
     {
-        public SetWorldName(Game game) : base(game)
+        public SetWorldName(Game game)
         {
         }
 
-        public SetWorldName() : base(null)
+        public SetWorldName()
         {
         }
 

--- a/Source/RimConnection/Settings/CommandOptionSettings.cs
+++ b/Source/RimConnection/Settings/CommandOptionSettings.cs
@@ -271,7 +271,9 @@ namespace RimConnection.Settings
             Widgets.Label(eventLabel, "<b>Events</b>");
 
             Rect silverCostLabel = new Rect(rect.width - 580f, rect.y, 75f, rect.height);
-            Widgets.Label(silverCostLabel, "<b>Silver Cost</b>");
+            // In the DonationAlerts version the cost represents the donation amount
+            // required to trigger the event.
+            Widgets.Label(silverCostLabel, "<b>Donation Amount</b>");
 
             Rect localCooldownLabel = new Rect(silverCostLabel);
             localCooldownLabel.x += localCooldownLabel.width + 75f;
@@ -424,7 +426,7 @@ namespace RimConnection.Settings
             int newGlobalCooldown = commandOption.globalCooldownMs / 1000;
             string globalCooldownLabel = newGlobalCooldown.ToString();
 
-            // Silver Cost
+            // Donation amount matching this event
             Widgets.TextFieldNumeric(rect2, ref newPrice, ref priceLabel, 0f);
             filteredRows[index].costSilverStore = newPrice;
 

--- a/Source/RimConnection/Settings/CommandOptionSettings.cs
+++ b/Source/RimConnection/Settings/CommandOptionSettings.cs
@@ -54,7 +54,8 @@ namespace RimConnection.Settings
                 return;
             }
 
-            RimConnectAPI.PostUpdatedCommandOptions(updatedCommandOptions);
+            // In the DonationAlerts version we only update the local settings
+            // without sending them to an external server.
 
             // Update the global CommandOptionList with the modified CommandOptionList
             this.cachedCommandOptionList.commandOptions = this.commandOptions;

--- a/Source/RimConnection/Settings/ResetCommandOptionsModal.cs
+++ b/Source/RimConnection/Settings/ResetCommandOptionsModal.cs
@@ -36,9 +36,7 @@ namespace RimConnection.Settings
                 List<ValidCommand> validCommands = ActionList.ActionListToApi().validCommands;
                 CommandOptionList commandOptionList = new CommandOptionList();
                 commandOptionList.commandOptions = validCommands.Select(validCommand => validCommand.toCommandOption()).ToList();
-                RimConnectAPI.PostUpdatedCommandOptions(commandOptionList);
-
-                // Update the global CommandOptionList with the modified CommandOptionList
+                // No server update required; apply the defaults locally
                 CommandOptionListController.commandOptionList = commandOptionList;
                 Log.Message("RimConnect items have been reset");
             }

--- a/Source/RimConnection/Settings/Settings.cs
+++ b/Source/RimConnection/Settings/Settings.cs
@@ -147,7 +147,12 @@ namespace RimConnection
                 else
                 {
                     initialiseSuccessful = false;
-                    Log.Error($"[RimConnect] Failed to connect to DonationAlerts. HTTP {response.StatusCode}. Check your token.");
+                    string extra = string.IsNullOrEmpty(response.ErrorMessage) ? "" : $" ({response.ErrorMessage})";
+                    if (response.StatusCode == 0)
+                    {
+                        extra = string.IsNullOrEmpty(extra) ? " (no response)" : extra;
+                    }
+                    Log.Error($"[RimConnect] Failed to connect to DonationAlerts. HTTP {(int)response.StatusCode}{extra}. Check your token or connection.");
                 }
             }
             catch (System.Exception e)

--- a/Source/RimConnection/Settings/Settings.cs
+++ b/Source/RimConnection/Settings/Settings.cs
@@ -117,7 +117,7 @@ namespace RimConnection
                 return;
             }
             // Ensure TLS 1.2 so HTTPS requests succeed on older .NET installs
-            System.Net.ServicePointManager.SecurityProtocol |= System.Net.SecurityProtocolType.Tls12;
+            System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
             var client = new RestClient("https://www.donationalerts.com/api/v1/");
             var request = new RestRequest("alerts/donations", Method.GET);
             request.AddHeader("Authorization", $"Bearer {donationToken}");
@@ -150,9 +150,13 @@ namespace RimConnection
                 {
                     initialiseSuccessful = false;
                     string extra = string.IsNullOrEmpty(response.ErrorMessage) ? "" : $" ({response.ErrorMessage})";
-                    if (response.StatusCode == 0)
+                    if (response.ErrorException != null)
                     {
-                        extra = string.IsNullOrEmpty(extra) ? " (no response)" : extra;
+                        extra += $" ({response.ErrorException.GetType().Name}: {response.ErrorException.Message})";
+                    }
+                    if (response.StatusCode == 0 && string.IsNullOrEmpty(extra))
+                    {
+                        extra = " (no response)";
                     }
                     Log.Error($"[RimConnect] Failed to connect to DonationAlerts. HTTP {(int)response.StatusCode}{extra}. Check your token or connection.");
                 }

--- a/Source/RimConnection/Settings/Settings.cs
+++ b/Source/RimConnection/Settings/Settings.cs
@@ -116,6 +116,8 @@ namespace RimConnection
                 initialiseSuccessful = false;
                 return;
             }
+            // Ensure TLS 1.2 so HTTPS requests succeed on older .NET installs
+            System.Net.ServicePointManager.SecurityProtocol |= System.Net.SecurityProtocolType.Tls12;
             var client = new RestClient("https://www.donationalerts.com/api/v1/");
             var request = new RestRequest("alerts/donations", Method.GET);
             request.AddHeader("Authorization", $"Bearer {donationToken}");

--- a/Source/RimConnection/Settings/Settings.cs
+++ b/Source/RimConnection/Settings/Settings.cs
@@ -116,8 +116,8 @@ namespace RimConnection
                 initialiseSuccessful = false;
                 return;
             }
-            // Ensure TLS 1.2 so HTTPS requests succeed on older .NET installs
-            System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
+            // Ensure TLS 1.2 is enabled so HTTPS requests succeed on older .NET installs
+            System.Net.ServicePointManager.SecurityProtocol |= System.Net.SecurityProtocolType.Tls12;
             var client = new RestClient("https://www.donationalerts.com/api/v1/");
             var request = new RestRequest("alerts/donations", Method.GET);
             request.AddHeader("Authorization", $"Bearer {donationToken}");

--- a/Source/RimConnection/Settings/Settings.cs
+++ b/Source/RimConnection/Settings/Settings.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.RegularExpressions;
-using RimConnection.API;
-using RimConnection.Settings;
+using RestSharp;
 using RimWorld;
 using UnityEngine;
 using Verse;
@@ -9,31 +7,15 @@ namespace RimConnection
 {
     public class RimConnectSettings : ModSettings
     {
-        public static string[] validCommands;
-
-#if DEBUG
-        public static string BASE_URL = "http://localhost:8080/";
-#else
-        public static string BASE_URL = "http://rimconnect-backend.herokuapp.com/";
-#endif
-
-        public static string secret = "";
-        public static string token = "";
+        public static string donationToken = "";
         public static bool initialiseSuccessful = false;
-
-        bool showSecret = false;
-
-        public static int silverAwardPoints = -1;
-
+        private bool showToken = false;
         private static float defaultWidth = 200f;
 
         public override void ExposeData()
         {
             base.ExposeData();
-
-            Scribe_Values.Look<string>(ref secret, "secret", "", true);
-            Scribe_Values.Look(ref silverAwardPoints, "silverAwardPoints");
-
+            Scribe_Values.Look(ref donationToken, "donationToken", "", true);
         }
 
         public void DoWindowContents(Rect rect)
@@ -42,7 +24,6 @@ namespace RimConnection
             Widgets.Label(accountLinkHeader, "<size=32>Account Link</size>");
 
             Rect statusGroup = new Rect(0, accountLinkHeader.y + accountLinkHeader.height + 10f, rect.width, 48f);
-
             GUI.BeginGroup(statusGroup);
 
             Rect statusLabel = new Rect(0, 0, defaultWidth, 24f);
@@ -52,131 +33,127 @@ namespace RimConnection
             if (initialiseSuccessful)
             {
                 Widgets.Label(statusLabel, "<color=green>Connected!</color>");
-
                 if (Widgets.ButtonText(connectionButton, "Reconnect"))
                 {
-                    ServerInitialise.Init();
+                    TryConnectDonationAlerts();
                 }
             }
             else
             {
                 Widgets.Label(statusLabel, "<color=red>Disconnected</color>");
-
                 if (Widgets.ButtonText(connectionButton, "Connect"))
                 {
-                    ServerInitialise.Init();
+                    TryConnectDonationAlerts();
                 }
             }
-
             GUI.EndGroup();
 
-            Rect secretGroup = new Rect(0, statusGroup.y + statusGroup.height + 20f, rect.width, 72f);
+            Rect tokenGroup = new Rect(0, statusGroup.y + statusGroup.height + 20f, rect.width, 72f);
+            GUI.BeginGroup(tokenGroup);
 
-            GUI.BeginGroup(secretGroup);
-
-            Rect secretLabel = new Rect(0, 0, defaultWidth, 24f);
+            Rect tokenLabel = new Rect(0, 0, defaultWidth, 24f);
             Rect pasteButton = new Rect(defaultWidth, 24f, defaultWidth, 24f);
             Rect warningLabel = new Rect(0, 48, 400f, 24f);
 
-            Widgets.Label(secretLabel, "Secret:");
-            secretLabel.x = secretLabel.width + WidgetRow.LabelGap;
-            
-            if (showSecret)
+            Widgets.Label(tokenLabel, "Donation Token:");
+            tokenLabel.x = tokenLabel.width + WidgetRow.LabelGap;
+            if (showToken)
             {
-                secret = Widgets.TextField(secretLabel, secret);
+                donationToken = Widgets.TextField(tokenLabel, donationToken);
             }
             else
             {
-                Widgets.Label(secretLabel, new string('*', secret.Length));
+                Widgets.Label(tokenLabel, new string('*', donationToken.Length));
             }
 
-            secretLabel.x += secretLabel.width + WidgetRow.LabelGap;
-            if (!showSecret && Widgets.ButtonText(secretLabel, "Show"))
+            tokenLabel.x += tokenLabel.width + WidgetRow.LabelGap;
+            if (!showToken && Widgets.ButtonText(tokenLabel, "Show"))
             {
-                showSecret = true;
+                showToken = true;
             }
-            else if (Widgets.ButtonText(secretLabel, "Hide"))
+            else if (showToken && Widgets.ButtonText(tokenLabel, "Hide"))
             {
-                showSecret = false;
+                showToken = false;
             }
 
             if (Widgets.ButtonText(pasteButton, "Paste from Clipboard"))
             {
-                secret = GUIUtility.systemCopyBuffer;
+                donationToken = GUIUtility.systemCopyBuffer;
             }
-
-            Widgets.Label(warningLabel, "<color=red>Warning: Do not show your secret on stream!</color>");
-
+            Widgets.Label(warningLabel, "<color=red>Warning: Do not show your token on stream!</color>");
             GUI.EndGroup();
 
-            Rect loyaltyStoreHeader = new Rect(0, secretGroup.y + secretGroup.height + 10f, rect.width, 64f);
-            Widgets.Label(loyaltyStoreHeader, "<size=32>Loyalty Settings</size>");
+            Rect eventsHeader = new Rect(0, tokenGroup.y + tokenGroup.height + 10f, rect.width, 64f);
+            Widgets.Label(eventsHeader, "<size=32>Donation Event Settings</size>");
 
-            Rect itemStoreGroup = new Rect(0, loyaltyStoreHeader.y + loyaltyStoreHeader.height + 10f, rect.width, 24f);
-
-            if (CommandOptionListController.commandOptionList != null)
+            Rect itemStoreGroup = new Rect(0, eventsHeader.y + eventsHeader.height + 10f, rect.width, 24f);
+            GUI.BeginGroup(itemStoreGroup);
+            Rect itemLabel = new Rect(0, 0, defaultWidth, 24f);
+            Widgets.Label(itemLabel, "Events:");
+            itemLabel.x += itemLabel.width + WidgetRow.LabelGap;
+            if (Widgets.ButtonText(itemLabel, "Edit"))
             {
-                GUI.BeginGroup(itemStoreGroup);
+                CommandOptionSettings window = new CommandOptionSettings();
+                Find.WindowStack.TryRemove(window.GetType());
+                Find.WindowStack.Add(window);
+            }
+            itemLabel.x += itemLabel.width + WidgetRow.LabelGap;
+            if (Widgets.ButtonText(itemLabel, "Reset"))
+            {
+                ResetCommandOptionsModal window = new ResetCommandOptionsModal();
+                Find.WindowStack.TryRemove(window.GetType());
+                Find.WindowStack.Add(window);
+            }
+            GUI.EndGroup();
+        }
 
-                Rect itemLabel = new Rect(0, 0, defaultWidth, 24f);
-                Widgets.Label(itemLabel, "Loyalty Store Items:");
-
-                itemLabel.x += itemLabel.width + WidgetRow.LabelGap;
-
-                if (Widgets.ButtonText(itemLabel, "Items"))
+        private void TryConnectDonationAlerts()
+        {
+            if (string.IsNullOrEmpty(donationToken))
+            {
+                Log.Error("DonationAlerts token is empty! Please enter your token.");
+                initialiseSuccessful = false;
+                return;
+            }
+            var client = new RestClient("https://www.donationalerts.com/api/v1/");
+            var request = new RestRequest("alerts/donations", Method.GET);
+            request.AddHeader("Authorization", $"Bearer {donationToken}");
+            try
+            {
+                var response = client.Execute<DonationAlertsResponse>(request);
+                if (response.StatusCode == System.Net.HttpStatusCode.OK)
                 {
-                    CommandOptionSettings window = new CommandOptionSettings();
-                    Find.WindowStack.TryRemove(window.GetType());
-                    Find.WindowStack.Add(window);
+                    DonationAlertsResponse data = response.Data;
+                    if (data != null && data.data != null)
+                    {
+                        int maxId = 0;
+                        foreach (var donation in data.data)
+                        {
+                            if (donation.id > maxId)
+                                maxId = donation.id;
+                        }
+                        initialiseSuccessful = true;
+                        DonationPoller.lastDonationId = maxId;
+                        Log.Message("[RimConnect] Connected to DonationAlerts successfully.");
+                    }
+                    else
+                    {
+                        initialiseSuccessful = true;
+                        DonationPoller.lastDonationId = 0;
+                        Log.Message("[RimConnect] Connected to DonationAlerts (no donations yet).");
+                    }
                 }
-
-                itemLabel.x += itemLabel.width + WidgetRow.LabelGap;
-                if (Widgets.ButtonText(itemLabel, "Reset")) {
-                    ResetCommandOptionsModal window = new ResetCommandOptionsModal();
-                    Find.WindowStack.TryRemove(window.GetType());
-                    Find.WindowStack.Add(window);
+                else
+                {
+                    initialiseSuccessful = false;
+                    Log.Error($"[RimConnect] Failed to connect to DonationAlerts. HTTP {response.StatusCode}. Check your token.");
                 }
-
-                GUI.EndGroup();
             }
-            else
+            catch (System.Exception e)
             {
-                Widgets.Label(itemStoreGroup, "Cannot edit items without proper connection to RimConnect Servers");
+                initialiseSuccessful = false;
+                Log.Error("[RimConnect] Error connecting to DonationAlerts: " + e.Message);
             }
-
-            Rect silversPerGroup = new Rect(0, itemStoreGroup.y + itemStoreGroup.height + 10f, rect.width, 24f);
-            GUI.BeginGroup(silversPerGroup);
-
-            Rect silverLabel = new Rect(0, 0, defaultWidth, 24f);
-            Widgets.Label(silverLabel, "Silver per 2 minutes:");
-
-            silverLabel.x += silverLabel.width + WidgetRow.LabelGap;
-
-            string silverAwardPointsBuffer = silverAwardPoints.ToString();
-            Widgets.TextFieldNumeric(silverLabel, ref silverAwardPoints, ref silverAwardPointsBuffer);
-
-            silverLabel.x += silverLabel.width + WidgetRow.LabelGap;
-
-            if (Widgets.ButtonText(silverLabel, "Update on Server"))
-            {
-                RimConnectAPI.PostConfig();
-            }
-
-            GUI.EndGroup();
-
-            Rect AdditionalInfoGroup = new Rect(0, silversPerGroup.y + 70f, rect.width, 50f);
-            GUI.BeginGroup(AdditionalInfoGroup);
-
-            Rect additionalInfoLabel = new Rect(0, 0, 2 * defaultWidth, 24f);
-            Widgets.Label(additionalInfoLabel, "Did you know that the RimConnect mod is now open source?");
-
-            Rect githubLinkLabel = new Rect(2 * defaultWidth + 2 * WidgetRow.LabelGap, 0, defaultWidth, 24f);
-            if(Widgets.ButtonText(githubLinkLabel, "Check it out here"))
-            {
-                Application.OpenURL("https://github.com/Better-Scenes/RimConnect-mod");
-            }
-
-            GUI.EndGroup();
         }
     }
 }

--- a/Source/RimConnection/Settings/Settings.cs
+++ b/Source/RimConnection/Settings/Settings.cs
@@ -2,6 +2,7 @@ using RestSharp;
 using RimWorld;
 using UnityEngine;
 using Verse;
+using RimConnection.Settings;
 
 namespace RimConnection
 {


### PR DESCRIPTION
## Summary
- replace Twitch settings with DonationAlerts token
- fetch donations via DonationAlerts API
- queue and run events when donation amount matches configured cost
- initialise local event list on mod load

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686218cda218832ab0ac8c50b02d4d8e